### PR TITLE
Spawning and map icon

### DIFF
--- a/Prototypes/queen-spawner.lua
+++ b/Prototypes/queen-spawner.lua
@@ -4,17 +4,8 @@ local queenSpawner = table.deepcopy(data.raw["unit-spawner"]["biter-spawner"])
 queenSpawner.name = "biter-queen-spawner"
 queenSpawner.max_health = 10000
 queenSpawner.max_count_of_owned_units = 1
+queenSpawner.autoplace = nil
 
-queenSpawner.result_units = {{ "biter-queen", {{0.0, 0.3}, {0.35, 0}} }}
+queenSpawner.result_units = {{ "biter-queen", {{0.0, 1}} }}
 
 data:extend({queenSpawner})
-
-    -- evolution factor explanation:
-
-    -- from evolution_factor 0.3 the weight for medium-biter is linearly rising from 0 to 0.3
-    -- this means for example that when the evolution_factor is 0.45 the probability of spawning
-    -- a small biter is 66% while probability for medium biter is 33%.
-    -- res[2] = {"tame-medium-biter", {{0.3, 0.0}, {0.6, 0.3}, {0.8, 0.1}}}
-    -- for evolution factor of 1 the spawning probabilities are: small-biter 0%, medium-biter 1/7, big-biter 4/7, behemoth biter 3/7
-    -- res[3] = {"tame-big-biter", {{0.6, 0.0}, {1.0, 0.4}}}
-    -- res[4] = {"tame-behemoth-biter", {{0.99, 0.0}, {1.0, 0.3}}}

--- a/Prototypes/queen.lua
+++ b/Prototypes/queen.lua
@@ -1,7 +1,7 @@
-local queen = table.deepcopy(data.raw["unit"]["small-biter"]) -- copy the table (lua table) that defines the small-biter into the queen variable
+local queen = table.deepcopy(data.raw["unit"]["behemoth-biter"]) -- copy the table (lua table) that defines the behemoth-biter into the queen variable
 
 queen.name = "biter-queen"
 
-queen.max_health = 1000
+queen.max_health = 100000
 
 data:extend({queen})

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # Factorio-Queen-Biter
 A mod for factorio that aims to add a queen biter that spawns within the game and adds another interesting enemy into the mix.
+
+
+### Helpful Tid-bits
+
+When working with EnemySpawnerPrototypes, they have a result_units property that caused me some initial confusion.
+The result_units is an array of UnitSpawnDefinitions: {unit, spawn_points[SpawnPoint]}.  The SpawnPoint array
+takes in the following: evolution_factor and spawn_weight properties.
+> evolution_factor: Evolution factor is a property that states at what pollution level the specificed unit will begin to spawn,
+for example: {0.0, 1}, the following would start spawning the specified biter at 0 pollution, with 100% spawn chance meaning
+we're talking about a hive that would always spawn one unit type.
+
+> spawn_weight: In the above example {0.0, 1} 0.0 is the evolution_factor, and 1 is the spawn_weight.  This is the percentage chance
+that the given unit will spawn from the hive when spawning units.  1 being 100% in this example.
+
+    -- evolution factor explanation:
+
+    -- from evolution_factor 0.3 the weight for medium-biter is linearly rising from 0 to 0.3
+    -- this means for example that when the evolution_factor is 0.45 the probability of spawning
+    -- a small biter is 66% while probability for medium biter is 33%.
+    -- res[2] = {"tame-medium-biter", {{0.3, 0.0}, {0.6, 0.3}, {0.8, 0.1}}}
+    -- for evolution factor of 1 the spawning probabilities are: small-biter 0%, medium-biter 1/7, big-biter 4/7, behemoth biter 3/7
+    -- res[3] = {"tame-big-biter", {{0.6, 0.0}, {1.0, 0.4}}}
+    -- res[4] = {"tame-behemoth-biter", {{0.99, 0.0}, {1.0, 0.3}}}

--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,33 @@
-# Verison: 0.1.0
+# Verison: 0.2.0
+
 ## Date: 1/4/2024
 
 ### Additions:
-- Add `queen-spawner.lua` prototype that deep copies `biter-spawner` and changes a few properties
-- Add `queen.lua` prototype that deep copies `small-biter` and changes a few properties
-- Add `data.lua` and require both `queen-spanwer` and `queen` prototypes
-- Add info.json that carries mod specific information
-- Add `locale/en.cfg` to specify names and definitions for the `queen` and `queen-spawner` prototypes
++ Helpful tid-bits section with some brain puke added to Readme
++ Control.lua file containing several event listeners
++ When biter-queen is spawned, player will now chart a small square around the spawning hive
++ When player spawns in an attempt will now be made to spawn a queen-spawner
++ When we spawn queen-spawner, player will chart a small square around the spawning hive
++ After player has charted a small square an attempt will be made to place a chart_tag, permenantly marking the hives location
++ Added gps tagging of attempted spawn location for debugging
+
+### Changes:
+* Queen-spawner will no longer be placed on worldgen
+* Queen-spawner will now spwan biter-queen 100% of the time at any pollution level
+* Biter-queen health increased to 100,000
+* Biter-queen now uses behemoth-biter Prototype instead of small-biter
+
+### Removals:
+- Code comments in queen-spawner.lua have been temporarily moved to Readme.md (still need formatted / work)
+
+## Date: 1/4/2024
+
+### Additions:
++ Add `queen-spawner.lua` prototype that deep copies `biter-spawner` and changes a few properties
++ Add `queen.lua` prototype that deep copies `small-biter` and changes a few properties
++ Add `data.lua` and require both `queen-spanwer` and `queen` prototypes
++ Add info.json that carries mod specific information
++ Add `locale/en.cfg` to specify names and definitions for the `queen` and `queen-spawner` prototypes
 
 ### Changes:
 N/a.

--- a/control.lua
+++ b/control.lua
@@ -1,0 +1,44 @@
+script.on_event(defines.events.on_entity_spawned,
+    function(event)
+        local entity = event.entity
+        local spawner = event.spawner
+
+        if entity.name == "biter-queen" then
+           local playerForce = game.forces["player"]
+
+           playerForce.chart("nauvis", {{spawner.position["x"] - 10, spawner.position["y"] - 10}, {spawner.position["x"] + 10, spawner.position["y"] + 10}})
+        end
+    end
+)
+
+-- On player created, spawn biter-queen-spawner 200-500 tiles away from 0,0
+script.on_event(defines.events.on_player_created,
+    function(event)
+        local player = game.get_player(event.player_index)
+        local surface = player.surface
+        local spawnPosition = {math.random(player.position["x"] + 200, player.position["x"] + 500), math.random(player.position["y"] + 200, player.position["y"] + 500)}
+
+        -- This line is for testing, will gps tag the location we attempted to spawn the queen at
+        local gpsTag = "[gps=" .. spawnPosition[1] .. "," .. spawnPosition[2] .. "]"
+
+        player.force.chart("nauvis", {{spawnPosition[1] - 10, spawnPosition[2] - 10}, {spawnPosition[1] + 10, spawnPosition[2] + 10}})
+
+        -- May be refactor opportunity for math.random calls
+        surface.create_entity({name = "biter-queen-spawner", position = spawnPosition})
+        player.force.print(gpsTag)
+    end
+)
+
+script.on_event(defines.events.on_entity_spawned,
+    function(event)
+        local spawner = event.spawner
+        local spawnedEntity = event.entity
+        local playerForce = game.forces["player"]
+
+        -- Charting the location may not be necessary here.  Leaving as backup.
+        if spawnedEntity.name == "biter-queen" then
+            playerForce.chart("nauvis", {{spawner.position["x"] - 20, spawner.position["y"] - 20}, {spawner.position["x"] + 20, spawner.position["y"] + 20}})
+            playerForce.add_chart_tag("nauvis", {position = spawner.position, icon = {type = "virtual", name = "signal-info"}, text = "Biter Queen Hive"})
+        end
+    end
+)

--- a/control.lua
+++ b/control.lua
@@ -6,7 +6,11 @@ script.on_event(defines.events.on_entity_spawned,
         if entity.name == "biter-queen" then
            local playerForce = game.forces["player"]
 
-           playerForce.chart("nauvis", {{spawner.position["x"] - 10, spawner.position["y"] - 10}, {spawner.position["x"] + 10, spawner.position["y"] + 10}})
+           -- This chart may not be necessary, but prevents a situation in 
+           -- whichbiter-queen isn't spawned until initial chart has worn 
+           -- off.  As this would cause the adding of chart tag to fail.
+           playerForce.chart("nauvis", {{spawner.position["x"] - 20, spawner.position["y"] - 20}, {spawner.position["x"] + 20, spawner.position["y"] + 20}})
+           playerForce.add_chart_tag("nauvis", {position = spawner.position, icon = {type = "virtual", name = "signal-info"}, text = "Biter Queen Hive"})
         end
     end
 )
@@ -16,29 +20,17 @@ script.on_event(defines.events.on_player_created,
     function(event)
         local player = game.get_player(event.player_index)
         local surface = player.surface
+        -- May be refactor opportunity for math.random calls as these aren't
+        -- truly random.
         local spawnPosition = {math.random(player.position["x"] + 200, player.position["x"] + 500), math.random(player.position["y"] + 200, player.position["y"] + 500)}
 
-        -- This line is for testing, will gps tag the location we attempted to spawn the queen at
+        -- This line is for testing, will gps tag the location we attempted to
+        -- spawn the queen at
         local gpsTag = "[gps=" .. spawnPosition[1] .. "," .. spawnPosition[2] .. "]"
 
-        player.force.chart("nauvis", {{spawnPosition[1] - 10, spawnPosition[2] - 10}, {spawnPosition[1] + 10, spawnPosition[2] + 10}})
+        player.force.chart("nauvis", {{spawnPosition[1] - 20, spawnPosition[2] - 20}, {spawnPosition[1] + 20, spawnPosition[2] + 20}})
 
-        -- May be refactor opportunity for math.random calls
         surface.create_entity({name = "biter-queen-spawner", position = spawnPosition})
         player.force.print(gpsTag)
-    end
-)
-
-script.on_event(defines.events.on_entity_spawned,
-    function(event)
-        local spawner = event.spawner
-        local spawnedEntity = event.entity
-        local playerForce = game.forces["player"]
-
-        -- Charting the location may not be necessary here.  Leaving as backup.
-        if spawnedEntity.name == "biter-queen" then
-            playerForce.chart("nauvis", {{spawner.position["x"] - 20, spawner.position["y"] - 20}, {spawner.position["x"] + 20, spawner.position["y"] + 20}})
-            playerForce.add_chart_tag("nauvis", {position = spawner.position, icon = {type = "virtual", name = "signal-info"}, text = "Biter Queen Hive"})
-        end
     end
 )

--- a/control.lua
+++ b/control.lua
@@ -6,8 +6,8 @@ script.on_event(defines.events.on_entity_spawned,
         if entity.name == "biter-queen" then
            local playerForce = game.forces["player"]
 
-           -- This chart may not be necessary, but prevents a situation in 
-           -- whichbiter-queen isn't spawned until initial chart has worn 
+           -- This chart may not be necessary, but prevents a situation in
+           -- which biter-queen isn't spawned until initial chart has worn
            -- off.  As this would cause the adding of chart tag to fail.
            playerForce.chart("nauvis", {{spawner.position["x"] - 20, spawner.position["y"] - 20}, {spawner.position["x"] + 20, spawner.position["y"] + 20}})
            playerForce.add_chart_tag("nauvis", {position = spawner.position, icon = {type = "virtual", name = "signal-info"}, text = "Biter Queen Hive"})

--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -1,6 +1,6 @@
 [entity-name]
 biter-queen=Biter Queen
-biter-queen-spawner=Biter Queen Spawner
+biter-queen-spawner=Biter Queen Hive
 
 [entity-description]
 biter-queen=Is it... multiplying?


### PR DESCRIPTION
Version bump: 0.1.0 -> 0.2.0

### Additions:
+ Helpful tid-bits section with some brain puke added to Readme
+ Control.lua file containing several event listeners
+ When biter-queen is spawned, player will now chart a small square around the spawning hive
+ When player spawns in an attempt will now be made to spawn a queen-spawner
+ When we spawn queen-spawner, player will chart a small square around the spawning hive
+ After player has charted a small square an attempt will be made to place a chart_tag, permenantly marking the hives location
+ Added gps tagging of attempted spawn location for debugging

### Changes:
- Queen-spawner will no longer be placed on worldgen
- Queen-spawner will now spwan biter-queen 100% of the time at any pollution level
- Biter-queen health increased to 100,000
- Biter-queen now uses behemoth-biter Prototype instead of small-biter

### Removals:
- Code comments in queen-spawner.lua have been temporarily moved to Readme.md (still need formatted / work)

Closes #2 
Closes #3 